### PR TITLE
Implement intrinsic parameter behavior

### DIFF
--- a/Assets/Scripts/MessageHandler.cs
+++ b/Assets/Scripts/MessageHandler.cs
@@ -50,10 +50,10 @@ public static class MessageHandler
         camera.StreamWidth = (int)cameraStreamOpenRequest["width"];
         camera.StreamHeight = (int)cameraStreamOpenRequest["height"];
         camera.IsStreaming = true;
-        if (cameraStreamOpenRequest.ContainsKey("intrinsicParameters"))
+        JArray intrinsicParameters = (JArray)cameraStreamOpenRequest["intrinsicParameters"];
+        if (intrinsicParameters != null)
         {
-            camera.IntrinsicParameters = ((JArray)cameraStreamOpenRequest["intrinsicParameters"])
-                .ToObject<float[]>();
+            camera.IntrinsicParameters = intrinsicParameters.ToObject<float[]>();
         }
     }
 

--- a/Assets/Scripts/MessageHandler.cs
+++ b/Assets/Scripts/MessageHandler.cs
@@ -50,6 +50,11 @@ public static class MessageHandler
         camera.StreamWidth = (int)cameraStreamOpenRequest["width"];
         camera.StreamHeight = (int)cameraStreamOpenRequest["height"];
         camera.IsStreaming = true;
+        if (cameraStreamOpenRequest.ContainsKey("intrinsicParameters"))
+        {
+            camera.IntrinsicParameters = ((JArray)cameraStreamOpenRequest["intrinsicParameters"])
+                .ToObject<float[]>();
+        }
     }
 
     private static void HandleCameraStreamCloseRequest(Rover rover, JObject cameraStreamCloseRequest)

--- a/Assets/Scripts/RoverCamera.cs
+++ b/Assets/Scripts/RoverCamera.cs
@@ -39,6 +39,34 @@ public class RoverCamera : MonoBehaviour
     public int StreamHeight { get; set; }
 
     /// <summary>
+    /// A flattened 3x3 matrix representing the intrinsic parameters of this
+    /// camera.
+    /// </summary>
+    public float[] IntrinsicParameters
+    {
+        set
+        {
+            float f = 1.0f;  // focal length can be arbitrary.
+
+            float ax = value[0];
+            float ay = value[4];
+            float px = value[2];
+            float py = value[5];
+
+            float sizeX = f * StreamWidth / ax;
+            float sizeY = f * StreamHeight / ay;
+
+            float shiftX = -(px - StreamWidth / 2.0f) / StreamWidth;
+            float shiftY = (py - StreamHeight / 2.0f) / StreamHeight;
+
+            _camera.usePhysicalProperties = true;
+            _camera.sensorSize = new Vector2(sizeX, sizeY);
+            _camera.focalLength = f;
+            _camera.lensShift = new Vector2(shiftX, shiftY);
+        }
+    }
+
+    /// <summary>
     /// Whether this camera is streaming to the rover server.
     /// </summary>
     public bool IsStreaming

--- a/Assets/Scripts/RoverCamera.cs
+++ b/Assets/Scripts/RoverCamera.cs
@@ -46,7 +46,7 @@ public class RoverCamera : MonoBehaviour
     {
         set
         {
-            float f = 1.0f;  // focal length can be arbitrary.
+            float f = 1.0f;  // focal length can be anything but 0.
 
             float ax = value[0];
             float ay = value[4];


### PR DESCRIPTION
Adds the ability for the server to send intrinsic parameters for the rover cameras. This is done via the camera stream open request. 