### PR TITLE
Fix lag in rover <-> sim communication

### DIFF
--- a/Assets/Scripts/RoverSocket.cs
+++ b/Assets/Scripts/RoverSocket.cs
@@ -74,7 +74,7 @@ public class RoverSocket : MonoBehaviour
     {
         new Thread(() =>
         {
-            while (_socket.IsAlive)
+            while (IsConnected)
             {
                 if (_outgoingMessages.TryDequeue(out JObject message))
                 {


### PR DESCRIPTION
Finally fixed the longstanding bug where only packets sent from the simulator to the rover code was lagging very hard! This bug seemingly only existed on some platforms, but was caused by the use of `_socket.IsAlive`.

Whenever `IsAlive` is accessed, it would actually send a ping to the rover code and wait for a pong, which (on my machine) could take up to 40ms. It does this every loop iteration (every packet) so the max throughput ended up being 25 packets/sec, which was way less than what we needed.

If we just check the `IsConnected` flag instead, it avoids the ping, and results in much faster communication, and no delay.