### PR TITLE
Fix motor position request logic

### DIFF
--- a/Assets/Scenes/Simulator.unity
+++ b/Assets/Scenes/Simulator.unity
@@ -1155,7 +1155,8 @@ MonoBehaviour:
   _maxLimitPosition: 15
   _potentiometerOffset: 0
   _statusReportPeriod: 0.033333335
-  _speed: 40
+  _openLoopSpeed: 40
+  _closedLoopSpeed: 40
   _gearRatio: 1
   _leftFinger: {fileID: 5192463422970891476}
   _rightFinger: {fileID: 4511818124128450315}
@@ -2453,7 +2454,8 @@ MonoBehaviour:
   _maxLimitPosition: 9720
   _potentiometerOffset: 0
   _statusReportPeriod: 0.033333335
-  _speed: 40
+  _openLoopSpeed: 40
+  _closedLoopSpeed: 180
   _gearRatio: 1
   _axis: {x: 0, y: 0, z: 1}
 --- !u!1 &919132147660652431
@@ -2494,7 +2496,8 @@ MonoBehaviour:
   _maxLimitPosition: -18.2
   _potentiometerOffset: 0
   _statusReportPeriod: 0.033333335
-  _speed: 40
+  _openLoopSpeed: 40
+  _closedLoopSpeed: 180
   _gearRatio: 1
   _axis: {x: 1, y: 0, z: 0}
 --- !u!1 &919132148619690579
@@ -2609,7 +2612,8 @@ MonoBehaviour:
   _maxLimitPosition: 9000
   _potentiometerOffset: 0
   _statusReportPeriod: 0.033333335
-  _speed: 40
+  _openLoopSpeed: 40
+  _closedLoopSpeed: 40
   _gearRatio: 1
   _axis: {x: 0, y: 1, z: 0}
 --- !u!64 &919132148984513420
@@ -2664,7 +2668,8 @@ MonoBehaviour:
   _maxLimitPosition: 169.1
   _potentiometerOffset: 0
   _statusReportPeriod: 0.033333335
-  _speed: 40
+  _openLoopSpeed: 40
+  _closedLoopSpeed: 180
   _gearRatio: 1
   _axis: {x: 1, y: 0, z: 0}
 --- !u!23 &1220948287513773467
@@ -3151,7 +3156,8 @@ MonoBehaviour:
   _maxLimitPosition: 90
   _potentiometerOffset: 0
   _statusReportPeriod: 0.03333334
-  _speed: 40
+  _openLoopSpeed: 40
+  _closedLoopSpeed: 180
   _gearRatio: 1
   _axis: {x: 1, y: 0, z: 0}
 --- !u!23 &5985188835100470529

--- a/Assets/Scripts/MessageHandler.cs
+++ b/Assets/Scripts/MessageHandler.cs
@@ -51,7 +51,7 @@ public static class MessageHandler
             return;
         }
         // Convert from millidegrees to degrees.
-        motor.TargetPosition = (float)motorPositionRequest["position"] * 0.001f;
+        motor.TargetPosition = -(float)motorPositionRequest["position"] * 0.001f;
         motor.Mode = Motor.RunMode.RunToPosition;
     }
 


### PR DESCRIPTION
- Needed to invert target position when handling motor position request packets (since unity has inverted angles)
- Change how the target position is tracked, instead of using the old smoothing system just follow the max velocity, and when we're close to the target then just reduce the velocity to make the joint go to the target at the next timestep
- Use different max speeds for open loop and closed loop control, since the normal velocity is too slow for closed loop