### PR TITLE
Changed the names of the cameras

### DIFF
--- a/Assets/Scenes/Simulator.unity
+++ b/Assets/Scenes/Simulator.unity
@@ -2314,7 +2314,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c82dca69731416449ee97f7492e49c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _cameraName: hand
+  _cameraName: mast
 --- !u!20 &1647191664
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Simulator.unity
+++ b/Assets/Scenes/Simulator.unity
@@ -1679,7 +1679,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c82dca69731416449ee97f7492e49c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _cameraName: front
+  _cameraName: hand
 --- !u!20 &1161797000
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Simulator.unity
+++ b/Assets/Scenes/Simulator.unity
@@ -1591,7 +1591,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c82dca69731416449ee97f7492e49c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _cameraName: rear
+  _cameraName: wrist
 --- !u!20 &1141722569
 Camera:
   m_ObjectHideFlags: 0
@@ -2314,7 +2314,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c82dca69731416449ee97f7492e49c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _cameraName: upperArm
+  _cameraName: hand
 --- !u!20 &1647191664
 Camera:
   m_ObjectHideFlags: 0

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The simulator is able to simulate the motors with the following names:
 
 ## Cameras
 The simulator is able to simulate the cameras with the following names:
-- front
-- rear
-- upperArm
+- mast
+- hand
+- wrist
 
 ## Additional Hardware Devices
 The simulator is also able to simulate the following hardware devices:
@@ -131,7 +131,7 @@ Sent from the rover server to instruct the simulator to begin providing a camera
 ```
 
 ### Parameters
-- `camera` - the name of the camera
+- `camera` - the name of the camera: `mast|hand|wrist`
 - `fps` - the frames per second of the stream
 - `width` - the width of the stream in pixels
 - `height` - the height of the stream in pixels
@@ -150,7 +150,7 @@ Sent from the rover server to instruct the simulator to stop providing a camera 
 ```
 
 ### Parameters
-- `camera` - the name of the camera
+- `camera` - the name of the camera: `mast|hand|wrist`
 
 ## Camera Stream Report
 ### Description
@@ -166,7 +166,7 @@ Sent from the simulator to inform the rover server of a single frame of a camera
 ```
 
 ### Parameters
-- `camera` - the name of the camera
+- `camera` - the name of the camera: `mast|hand|wrist`
 - `data` - the frame in JPG format encoded as a base-64 string
 
 ## Rover True Pose Report


### PR DESCRIPTION
Related to: https://github.com/huskyroboticsteam/mission-control/pull/69 and https://github.com/huskyroboticsteam/Resurgence/pull/325
Changed the names of the cameras:
- `upperArm` -> `mast`
- `rear` -> `wrist`
- `front` -> `hand`