### PR TITLE
Camera Revamp

### DIFF
--- a/Assets/Scenes/Simulator.unity
+++ b/Assets/Scenes/Simulator.unity
@@ -1763,6 +1763,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _cameraName: wrist
+  _cameraID: 30
 --- !u!20 &1141722569
 Camera:
   m_ObjectHideFlags: 0
@@ -1851,6 +1852,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _cameraName: hand
+  _cameraID: 20
 --- !u!20 &1161797000
 Camera:
   m_ObjectHideFlags: 0
@@ -2486,6 +2488,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _cameraName: mast
+  _cameraID: 40
 --- !u!20 &1647191664
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MessageHandler.cs
+++ b/Assets/Scripts/MessageHandler.cs
@@ -57,43 +57,38 @@ public static class MessageHandler
 
     private static void HandleCameraStreamOpenRequest(Rover rover, JObject cameraStreamOpenRequest)
     {
-        string cameraName = (string)cameraStreamOpenRequest["camera"];
-        RoverCamera camera = rover.GetCamera(cameraName);
+        int cameraID = (int)cameraStreamOpenRequest["cameraID"];
+        RoverCamera camera = rover.GetCamera(cameraID);
         if (camera == null)
         {
-            SimulatorConsole.WriteLine("Unknown camera: " + cameraName);
+            SimulatorConsole.WriteLine("Unknown camera ID: " + cameraID);
             return;
         }
         if (camera.IsStreaming)
         {
             SimulatorConsole.WriteLine(
-                "Attempted to stream camera that is already streaming: " + cameraName);
+                "Attempted to stream camera that is already streaming: " + camera.CameraName);
             return;
         }
         camera.StreamFps = (float)cameraStreamOpenRequest["fps"];
         camera.StreamWidth = (int)cameraStreamOpenRequest["width"];
         camera.StreamHeight = (int)cameraStreamOpenRequest["height"];
         camera.IsStreaming = true;
-        JArray intrinsicParameters = (JArray)cameraStreamOpenRequest["intrinsicParameters"];
-        if (intrinsicParameters != null)
-        {
-            camera.IntrinsicParameters = intrinsicParameters.ToObject<float[]>();
-        }
     }
 
     private static void HandleCameraStreamCloseRequest(Rover rover, JObject cameraStreamCloseRequest)
     {
-        string cameraName = (string)cameraStreamCloseRequest["camera"];
-        RoverCamera camera = rover.GetCamera(cameraName);
+        int cameraID = (int)cameraStreamCloseRequest["cameraID"];
+        RoverCamera camera = rover.GetCamera(cameraID);
         if (camera == null)
         {
-            SimulatorConsole.WriteLine("Unknown camera: " + cameraName);
+            SimulatorConsole.WriteLine("Unknown camera ID: " + cameraID);
             return;
         }
         if (!camera.IsStreaming)
         {
             SimulatorConsole.WriteLine(
-                "Attempted to close camera that is already closed: " + cameraName);
+                "Attempted to close camera that is already closed: " + camera.CameraName);
             return;
         }
         camera.IsStreaming = false;

--- a/Assets/Scripts/Rover.cs
+++ b/Assets/Scripts/Rover.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 public class Rover : MonoBehaviour
 {
     private IDictionary<string, Motor> _motors;
-    private IDictionary<string, RoverCamera> _cameras;
+    private IDictionary<int, RoverCamera> _cameras;
 
     /// A collection containing all of the motors on this rover.
     /// </summary>
@@ -40,9 +40,9 @@ public class Rover : MonoBehaviour
     /// Returns the camera on this rover with the specified name, nor null if
     /// none exists.
     /// </summary>
-    public RoverCamera GetCamera(string cameraName)
+    public RoverCamera GetCamera(int cameraID)
     {
-        _cameras.TryGetValue(cameraName, out RoverCamera camera);
+        _cameras.TryGetValue(cameraID, out RoverCamera camera);
         return camera;
     }
 
@@ -54,10 +54,10 @@ public class Rover : MonoBehaviour
             _motors[motor.MotorName] = motor;
         }
 
-        _cameras = new Dictionary<string, RoverCamera>();
+        _cameras = new Dictionary<int, RoverCamera>();
         foreach (RoverCamera camera in transform.GetComponentsInChildren<RoverCamera>())
         {
-            _cameras[camera.CameraName] = camera;
+            _cameras[camera.CameraID] = camera;
         }
     }
 }

--- a/Assets/Scripts/RoverCamera.cs
+++ b/Assets/Scripts/RoverCamera.cs
@@ -11,6 +11,8 @@ public class RoverCamera : MonoBehaviour
 {
     [SerializeField]
     private string _cameraName;
+    [SerializeField]
+    private int _cameraID;
     private bool _isStreaming;
     private Camera _camera;
     private RoverSocket _socket;
@@ -21,6 +23,14 @@ public class RoverCamera : MonoBehaviour
     public string CameraName
     {
         get { return _cameraName; }
+    }
+
+    /// <summary>
+    /// The ID that identifies this camera.
+    /// </summary>
+    public int CameraID
+    {
+        get { return _cameraID; }
     }
 
     /// <summary>
@@ -144,7 +154,7 @@ public class RoverCamera : MonoBehaviour
         JObject cameraStreamReport = new JObject()
         {
             ["type"] = "simCameraStreamReport",
-            ["camera"] = CameraName,
+            ["cameraID"] = CameraID,
             ["data"] = streamData
         };
         _socket.Send(cameraStreamReport);

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The simulator is able to simulate the motors with the following names:
 - hand
 
 ## Cameras
-The simulator is able to simulate the cameras with the following names:
-- mast
-- hand
-- wrist
+The simulator is able to simulate the cameras with the following IDs:
+- 40 (mast)
+- 30 (wrist)
+- 20 (hand)
 
 ## Additional Hardware Devices
 The simulator is also able to simulate the following hardware devices:
@@ -144,7 +144,7 @@ Sent from the rover server to instruct the simulator to stop providing a camera 
 ```
 {
   type: "simCameraStreamCloseRequest",
-  camera: string
+  cameraID: number,
 }
 ```
 
@@ -159,7 +159,7 @@ Sent from the simulator to inform the rover server of a single frame of a camera
 ```
 {
   type: "simCameraStreamReport",
-  camera: number,
+  cameraID: number,
   data: string
 }
 ```

--- a/README.md
+++ b/README.md
@@ -122,16 +122,15 @@ Sent from the rover server to instruct the simulator to begin providing a camera
 ```
 {
   type: "simCameraStreamOpenRequest",
-  camera: string,
+  cameraID: number,
   fps: number,
   width: number,
   height: number,
-  intrinsicParameters: number[9] | null
 }
 ```
 
 ### Parameters
-- `camera` - the name of the camera: `mast|hand|wrist`
+- `cameraID` - the id of the camera
 - `fps` - the frames per second of the stream
 - `width` - the width of the stream in pixels
 - `height` - the height of the stream in pixels

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Sent from the rover server to instruct the simulator to stop providing a camera 
 ```
 
 ### Parameters
-- `camera` - the name of the camera: `mast|hand|wrist`
+- `cameraID` - the id of the camera
 
 ## Camera Stream Report
 ### Description
@@ -159,13 +159,13 @@ Sent from the simulator to inform the rover server of a single frame of a camera
 ```
 {
   type: "simCameraStreamReport",
-  camera: string,
+  camera: number,
   data: string
 }
 ```
 
 ### Parameters
-- `camera` - the name of the camera: `mast|hand|wrist`
+- `cameraID` - the id of the camera
 - `data` - the frame in JPG format encoded as a base-64 string
 
 ## Rover True Pose Report


### PR DESCRIPTION
Changed CameraID to be the IDs used for video streaming, updated related functions to use the new numerical IDs.